### PR TITLE
Improved Protocol Stats Source

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react'
 
+export const PROTOCOL_STATS_API_URL = 'https://protocol-stats.api.cabana.fi'
+
 export const RICH_TEXT_FORMATTING: { [id: string]: (chunks: ReactNode) => JSX.Element } = {
   'purple-400': (chunks) => <span className='text-pt-purple-400'>{chunks}</span>,
   'teal': (chunks) => <span className='text-pt-teal'>{chunks}</span>

--- a/src/hooks/useFormattedProtocolStats.tsx
+++ b/src/hooks/useFormattedProtocolStats.tsx
@@ -29,9 +29,11 @@ export const useFormattedProtocolStats = () => {
 
   if (!!protocolStats) {
     return {
-      totalPrizes: `$${formatProtocolStatsValue(protocolStats.totalPrizes)}`,
-      tvl: `$${formatProtocolStatsValue(protocolStats.tvl)}`,
-      uniqueWallets: formatProtocolStatsValue(protocolStats.uniqueWallets, { hideLabel: true })
+      totalPrizes: `$${formatProtocolStatsValue(protocolStats.total.awarded.usd)}`,
+      tvl: `$${formatProtocolStatsValue(protocolStats.total.current.tvl.usd)}`,
+      uniqueWallets: formatProtocolStatsValue(protocolStats.total.current.users, {
+        hideLabel: true
+      })
     }
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { SECONDS_PER_DAY } from '@shared/utilities'
 import { useHydrateAtoms } from 'jotai/utils'
 import { GetStaticProps } from 'next'
 import { protocolStatsAtom } from 'src/serverAtoms'
-import { ProtocolStats } from 'src/types'
+import { AggregatedProtocolStats } from 'src/types'
 import { getMessages, getProtocolStats } from 'src/utils'
 import { CryptoSection } from '@components/Home/CryptoSection'
 import { HeroSection } from '@components/Home/HeroSection'
@@ -12,7 +12,7 @@ import { StatsSection } from '@components/Home/StatsSection'
 import { Layout } from '@components/Layout'
 
 interface HomePageProps {
-  protocolStats: ProtocolStats
+  protocolStats: AggregatedProtocolStats
   messages: IntlMessages
 }
 

--- a/src/serverAtoms.ts
+++ b/src/serverAtoms.ts
@@ -1,7 +1,7 @@
 import { atom, useAtomValue } from 'jotai'
-import { ProtocolStats } from './types'
+import { AggregatedProtocolStats } from './types'
 
-export const protocolStatsAtom = atom<ProtocolStats | undefined>(undefined)
+export const protocolStatsAtom = atom<AggregatedProtocolStats | undefined>(undefined)
 
 export const useProtocolStats = () => {
   const protocolStats = useAtomValue(protocolStatsAtom)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,11 @@
+export type AggregatedProtocolStats = {
+  total: ProtocolStats
+  v3: ProtocolStats
+  v4: ProtocolStats
+  v5: ProtocolStats
+}
+
 export interface ProtocolStats {
-  uniqueWallets: number
-  poolPrice: number
-  tvl: number
-  uniqueWinners: number
-  totalPrizes: number
+  current: { users: number; tvl: { eth: number; usd: number } }
+  awarded: { eth: number; usd: number }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,10 @@
 import deepmerge from 'deepmerge'
-import { ProtocolStats } from './types'
+import { PROTOCOL_STATS_API_URL } from './constants'
+import { AggregatedProtocolStats } from './types'
 
 export const getProtocolStats = async () => {
-  const results = await fetch('https://protocol-stats.ncookie.workers.dev')
-  const data: ProtocolStats = await results.json()
+  const results = await fetch(PROTOCOL_STATS_API_URL)
+  const data: AggregatedProtocolStats = await results.json()
   return data
 }
 


### PR DESCRIPTION
This PR updates the source of protocol stats from the temporary worker querying some basic V4 data and some hardcoded V3 stats to a full-fledged cloudflare worker querying accurate V3, V4 and V5 data with onchain queries and subgraph data.

This data is updated every 12 hours and retrieved extremely fast from a KV cache.

The API now being queried is the following: https://protocol-stats.api.cabana.fi

The code for this API can be found [here](https://github.com/GenerationSoftware/pooltogether-client-monorepo/tree/main/workers/protocol-stats-worker).